### PR TITLE
make end to end test work within docker container

### DIFF
--- a/docker-mvn.sh
+++ b/docker-mvn.sh
@@ -10,6 +10,8 @@ exec docker run -i ${tty_option} --rm \
   -v "$PWD/.npm:$USER_HOME/.npm" \
   -v "$PWD":/usr/src \
   -w /usr/src \
+  -p 8080:8080 \
+  -p 9229:9229 \
   -e MAVEN_CONFIG=$USER_HOME/.m2 \
   gcr.io/jenkinsxio/builder-maven-nodejs:0.1.617 \
   "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
-    <node.version>v10.16.0</node.version>
+    <node.version>v10.16.3</node.version>
     <npm.version>6.10.2</npm.version>
 
     <!-- IntelliJ generates new version properties here - move them above every now and then -->
@@ -124,7 +124,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install --ignore-scripts</arguments>
+              <arguments>install</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
I did some local tests until it finally worked.

The final culprit was for me `--ignore-scripts`, once that was removed chrome was installed automatically. 

Now the following command works for me:

    ./docker-mvn.sh mvn -Pchromeheadless integration-test

This will trigger at one point `npm run e2e_headless` and succeeds. Full output attached, excerpt here:  

```
[INFO] Starting selenium server... started - PID:  407
[INFO]
[INFO] [Test] Test Suite
[INFO] =====================
[INFO]
[INFO] Running:  default e2e tests
...
[INFO] OK. 2 assertions passed. (2.756s)
[INFO]
[INFO] INFO Selenium process finished.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:02 min
[INFO] Finished at: 2019-08-17T08:36:54Z
[INFO] ------------------------------------------------------------------------
```

[output.txt](https://github.com/dukecon-jx/dukecon_pwa/files/3511815/output.txt)
